### PR TITLE
ID4のレコードを削除

### DIFF
--- a/src/main/java/com/task10/crudapi_login/controller/ClientController.java
+++ b/src/main/java/com/task10/crudapi_login/controller/ClientController.java
@@ -62,4 +62,10 @@ public class ClientController {
         clientService.delete(id);
         return ResponseEntity.ok(Map.of("message", "data successfully deleted"));
     }
+
+    @DeleteMapping("clients/{name}")
+    public ResponseEntity<Map<String, String>> deleteName(@PathVariable("name") String name) {
+        clientService.deleteName(name);
+        return ResponseEntity.ok(Map.of("message", "data successfully deleted"));
+    }
 }

--- a/src/main/java/com/task10/crudapi_login/controller/ClientController.java
+++ b/src/main/java/com/task10/crudapi_login/controller/ClientController.java
@@ -9,6 +9,7 @@ import static org.springframework.web.servlet.function.RequestPredicates.path;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,5 +55,11 @@ public class ClientController {
     public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Validated ClientUpdateForm clientUpdateForm) {
         clientService.update(id, clientUpdateForm.getAge(), clientUpdateForm.getPhoneNumber());
         return ResponseEntity.ok(Map.of("message", "data successfully updated"));
+    }
+
+    @DeleteMapping("clients/{id}")
+    public ResponseEntity<Map<String, String>> delete(@PathVariable("id") int id) {
+        clientService.delete(id);
+        return ResponseEntity.ok(Map.of("message", "data successfully deleted"));
     }
 }

--- a/src/main/java/com/task10/crudapi_login/exception/ClientBadRequestException.java
+++ b/src/main/java/com/task10/crudapi_login/exception/ClientBadRequestException.java
@@ -1,0 +1,19 @@
+package com.task10.crudapi_login.exception;
+
+public class ClientBadRequestException extends RuntimeException {
+    public ClientBadRequestException() {
+        super();
+    }
+
+    public ClientBadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ClientBadRequestException(String message) {
+        super(message);
+    }
+
+    public ClientBadRequestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/task10/crudapi_login/exception/ClientExceptionHandler.java
+++ b/src/main/java/com/task10/crudapi_login/exception/ClientExceptionHandler.java
@@ -22,4 +22,16 @@ public class ClientExceptionHandler {
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(value = ClientBadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleResourceBadRequest(
+            ClientBadRequestException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
+++ b/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
@@ -28,4 +28,10 @@ public interface ClientMapper {
 
     @Delete("DELETE FROM clients WHERE id = #{id}")
     void delete(int id);
+
+    //nameが#{name}で始まるデータを削除
+    @Delete("DELETE FROM clients WHERE name like = #{name}")
+    void deleteName(String name);
+
+    Optional<Object> findByName(String name);
 }

--- a/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
+++ b/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
@@ -1,6 +1,7 @@
 package com.task10.crudapi_login.mapper;
 
 import com.task10.crudapi_login.entity.Client;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -24,4 +25,7 @@ public interface ClientMapper {
 
     @Update("UPDATE clients SET age = #{age}, phoneNumber = #{phoneNumber} WHERE id = #{id}")
     void update(Client client);
+
+    @Delete("DELETE FROM clients WHERE id = #{id}")
+    void delete(int id);
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientService.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientService.java
@@ -12,4 +12,6 @@ public interface ClientService {
     Client create(Client client);
 
     void update(int id, int age, String phoneNumber);
+
+    void delete(int id);
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientService.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientService.java
@@ -14,4 +14,6 @@ public interface ClientService {
     void update(int id, int age, String phoneNumber);
 
     void delete(int id);
+
+    void deleteName(String name);
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
@@ -40,4 +40,10 @@ public class ClientServiceImpl implements ClientService {
         client.setPhoneNumber(phoneNumber);
         clientMapper.update(client);
     }
+
+    @Override
+    public void delete(int id) {
+        clientMapper.findById(id).orElseThrow(() -> new ClientNotFoundException("resource not found :" + id));
+        clientMapper.delete(id);
+    }
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
@@ -1,5 +1,6 @@
 package com.task10.crudapi_login.service;
 
+import com.task10.crudapi_login.exception.ClientBadRequestException;
 import com.task10.crudapi_login.mapper.ClientMapper;
 import com.task10.crudapi_login.entity.Client;
 import com.task10.crudapi_login.exception.ClientNotFoundException;
@@ -45,5 +46,14 @@ public class ClientServiceImpl implements ClientService {
     public void delete(int id) {
         clientMapper.findById(id).orElseThrow(() -> new ClientNotFoundException("resource not found :" + id));
         clientMapper.delete(id);
+    }
+
+    @Override
+    public void deleteName(String name) {
+        if (clientMapper.findByName(name).isPresent()) {
+            clientMapper.deleteName(name);
+        } else {
+            throw new ClientBadRequestException("resource is bad Request");
+        }
     }
 }


### PR DESCRIPTION
# 概要
* clientsテーブルのID４の顧客データを削除する処理を実装しました。
* 存在しないIDの顧客データを削除しようとすると、エラーを返すバリデーションも併せて実装いたしました。

# 動作確認

## データの削除　*"clients{id}"*
レスポンス成功はステータスコード２００を想定し、存在しないIDをリクエストした場合は４０４を想定しています。
#### [ID4を削除処理]　
```java
curl --location --request DELETE 'http://localhost:8080/clients/4' \
```
![DELETE id4](https://github.com/minori-oya/task10/assets/138114043/104d0047-dcc7-4ffc-b51d-ee8c5e8e36f3)
#### [存在しないIDをリクエストした時の例外処理]
```java
curl --location --request DELETE 'http://localhost:8080/clients/99' \
```
![DELETE id99](https://github.com/minori-oya/task10/assets/138114043/162c5559-9892-40a1-ab06-522c0352da6d)
#### [clientsテーブル]
**変更前**
![DELETE 変更前](https://github.com/minori-oya/task10/assets/138114043/175b2fbf-3223-4ce6-84e3-412b0f252622)
**変更後**
![DELETE 変更後](https://github.com/minori-oya/task10/assets/138114043/3c6d3337-70f2-4deb-8d26-a6544b273cd8)