### PR TITLE
顧客データの読み取り処理の単体テストを実装

### DIFF
--- a/src/main/java/com/task10/crudapi_login/controller/ClientController.java
+++ b/src/main/java/com/task10/crudapi_login/controller/ClientController.java
@@ -9,6 +9,7 @@ import static org.springframework.web.servlet.function.RequestPredicates.path;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,5 +55,17 @@ public class ClientController {
     public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Validated ClientUpdateForm clientUpdateForm) {
         clientService.update(id, clientUpdateForm.getAge(), clientUpdateForm.getPhoneNumber());
         return ResponseEntity.ok(Map.of("message", "data successfully updated"));
+    }
+
+    @DeleteMapping("clients/{id}")
+    public ResponseEntity<Map<String, String>> delete(@PathVariable("id") int id) {
+        clientService.delete(id);
+        return ResponseEntity.ok(Map.of("message", "data successfully deleted"));
+    }
+
+    @DeleteMapping("clients/{name}")
+    public ResponseEntity<Map<String, String>> deleteName(@PathVariable("name") String name) {
+        clientService.deleteName(name);
+        return ResponseEntity.ok(Map.of("message", "data successfully deleted"));
     }
 }

--- a/src/main/java/com/task10/crudapi_login/exception/ClientBadRequestException.java
+++ b/src/main/java/com/task10/crudapi_login/exception/ClientBadRequestException.java
@@ -1,0 +1,19 @@
+package com.task10.crudapi_login.exception;
+
+public class ClientBadRequestException extends RuntimeException {
+    public ClientBadRequestException() {
+        super();
+    }
+
+    public ClientBadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ClientBadRequestException(String message) {
+        super(message);
+    }
+
+    public ClientBadRequestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/task10/crudapi_login/exception/ClientExceptionHandler.java
+++ b/src/main/java/com/task10/crudapi_login/exception/ClientExceptionHandler.java
@@ -22,4 +22,16 @@ public class ClientExceptionHandler {
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(value = ClientBadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleResourceBadRequest(
+            ClientBadRequestException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
+++ b/src/main/java/com/task10/crudapi_login/mapper/ClientMapper.java
@@ -1,6 +1,7 @@
 package com.task10.crudapi_login.mapper;
 
 import com.task10.crudapi_login.entity.Client;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -24,4 +25,13 @@ public interface ClientMapper {
 
     @Update("UPDATE clients SET age = #{age}, phoneNumber = #{phoneNumber} WHERE id = #{id}")
     void update(Client client);
+
+    @Delete("DELETE FROM clients WHERE id = #{id}")
+    void delete(int id);
+
+    //nameが#{name}で始まるデータを削除
+    @Delete("DELETE FROM clients WHERE name like = #{name}")
+    void deleteName(String name);
+
+    Optional<Object> findByName(String name);
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientService.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientService.java
@@ -12,4 +12,8 @@ public interface ClientService {
     Client create(Client client);
 
     void update(int id, int age, String phoneNumber);
+
+    void delete(int id);
+
+    void deleteName(String name);
 }

--- a/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
@@ -1,5 +1,6 @@
 package com.task10.crudapi_login.service;
 
+import com.task10.crudapi_login.exception.ClientBadRequestException;
 import com.task10.crudapi_login.mapper.ClientMapper;
 import com.task10.crudapi_login.entity.Client;
 import com.task10.crudapi_login.exception.ClientNotFoundException;
@@ -39,5 +40,20 @@ public class ClientServiceImpl implements ClientService {
         client.setAge(age);
         client.setPhoneNumber(phoneNumber);
         clientMapper.update(client);
+    }
+
+    @Override
+    public void delete(int id) {
+        clientMapper.findById(id).orElseThrow(() -> new ClientNotFoundException("resource not found :" + id));
+        clientMapper.delete(id);
+    }
+
+    @Override
+    public void deleteName(String name) {
+        if (clientMapper.findByName(name).isPresent()) {
+            clientMapper.deleteName(name);
+        } else {
+            throw new ClientBadRequestException("resource is bad Request");
+        }
     }
 }

--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.task10.crudapi_login.service;
+
+import com.task10.crudapi_login.entity.Client;
+import com.task10.crudapi_login.exception.ClientNotFoundException;
+import com.task10.crudapi_login.mapper.ClientMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ClientServiceImplTest {
+
+    @InjectMocks
+    ClientServiceImpl clientServiceImpl;
+
+    @Mock
+    ClientMapper clientMapper;
+
+    @Test
+    public void メソッド呼び出しで顧客データを全件取得すること() {
+        List<Client> client = List.of(
+                new Client(1, "田中一郎", 20, "09011111111"),
+                new Client(2, "鈴木次郎", 15, "08022222222"),
+                new Client(3, "佐藤三郎", 30, "08033333333")
+        );
+        doReturn(client).when(clientMapper).findAll();
+        List<Client> actual = clientServiceImpl.findAll();
+        assertThat(actual).isEqualTo(client);
+        verify(clientMapper, times(1)).findAll();
+    }
+
+    @Test
+    public void 存在する顧客のIDを指定した時に特定の顧客情報を返すこと() throws ClientNotFoundException {
+        doReturn(Optional.of(new Client(1, "田中一郎", 20, "09011111111"))).when(clientMapper).findById(1);
+
+        Client actual = clientServiceImpl.findById(1);
+        assertThat(actual).isEqualTo(new Client(1, "田中一郎", 20, "09011111111"));
+        verify(clientMapper, times(1)).findById(1);
+    }
+
+    @Test
+    public void 存在しないIDをリクエストした時にエラーを返す() throws ClientNotFoundException {
+        doReturn(Optional.empty()).when(clientMapper).findById(99);
+
+        assertThrows(ClientNotFoundException.class, () -> {
+            clientServiceImpl.findById(99);
+        });
+    }
+}


### PR DESCRIPTION
# 概要
Serviceの読み取り処理の単体テストを実装しました。  
実装した単体テストは顧客データの全件取得、特定ID情報の取得、存在しないIDをリクエストした時の例外処理になります。

# 動作確認
 ### 顧客データの読み取り処理　*findAll() / findById(#{id})*
* 登録データの全件取得 
![全件取得](https://github.com/minori-oya/task10/assets/138114043/2cffdf47-3a69-4334-b08e-087ee80bd10e)
 * ID1の顧客データを取得
![ID1](https://github.com/minori-oya/task10/assets/138114043/ecbe9e79-5745-49b9-bc27-3f7780a1d04e) 
* 存在しないIDをリクエストした時の例外処理 
![ID99](https://github.com/minori-oya/task10/assets/138114043/cc38e2c4-7b98-4f6a-b198-16bc3d5b0c8b)
