### PR TITLE
顧客データの登録処理の単体テストを実装

### DIFF
--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -55,4 +55,14 @@ public class ClientServiceImplTest {
             clientServiceImpl.findById(99);
         });
     }
+
+    @Test
+    public void 顧客データを新規登録する() {
+        Client client = new Client(4, "石田四郎", 45, "08044444444");
+        doNothing().when(clientMapper).insert(client);
+
+        Client actual = clientServiceImpl.create(client);
+        assertThat(actual).isEqualTo(new Client(4, "石田四郎", 45, "08044444444"));
+        verify(clientMapper, times(1)).insert(client);
+    }
 }


### PR DESCRIPTION
# 概要
Serviceの登録処理の単体テストを実装しました。
新規顧客データを登録するリクエストを送り、登録処理ができたことをテストで検証いたしました。

# 動作確認
### 登録処理　
<img width="1710" alt="POST" src="https://github.com/minori-oya/task10/assets/138114043/86d187af-8b2a-4e67-b9fd-26c892dc74c9">
