### PR TITLE
顧客データの更新処理の単体テストを実装

### DIFF
--- a/src/main/java/com/task10/crudapi_login/service/ClientService.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientService.java
@@ -11,7 +11,7 @@ public interface ClientService {
 
     Client create(Client client);
 
-    void update(int id, String name, int age, String phoneNumber);
+    Client update(int id, String name, int age, String phoneNumber);
 
     void delete(int id);
 

--- a/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
+++ b/src/main/java/com/task10/crudapi_login/service/ClientServiceImpl.java
@@ -35,12 +35,13 @@ public class ClientServiceImpl implements ClientService {
     }
 
     @Override
-    public void update(int id, String name, int age, String phoneNumber) {
+    public Client update(int id, String name, int age, String phoneNumber) {
         Client client = clientMapper.findById(id).orElseThrow(() -> new ClientNotFoundException("resource not found :" + id));
         client.setName(name);
         client.setAge(age);
         client.setPhoneNumber(phoneNumber);
         clientMapper.update(client);
+        return client;
     }
 
     @Override

--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -29,7 +30,7 @@ public class ClientServiceImplTest {
     public void メソッド呼び出しで顧客データを全件取得すること() {
         List<Client> client = List.of(
                 new Client(1, "田中一郎", 20, "09011111111"),
-                new Client(2, "鈴木次郎", 15, "08022222222"),
+                new Client(2, "鈴木二郎", 15, "08022222222"),
                 new Client(3, "佐藤三郎", 30, "08033333333")
         );
         doReturn(client).when(clientMapper).findAll();
@@ -64,5 +65,29 @@ public class ClientServiceImplTest {
         Client actual = clientServiceImpl.create(client);
         assertThat(actual).isEqualTo(new Client(4, "石田四郎", 45, "08044444444"));
         verify(clientMapper, times(1)).insert(client);
+    }
+
+    @Test
+    public void 顧客データの属性を全て更新すること() {
+        Client client = new Client(2, "鈴木二郎", 15, "08022222222");
+        doReturn(Optional.of(client)).when(clientMapper).findById(2);
+
+        doNothing().when(clientMapper).update(new Client(2, "山本二郎", 16, "09022222222"));
+
+        Client actual = clientServiceImpl.update(2, "山本二郎", 16, "09022222222");
+        assertThat(actual).isEqualTo(new Client(2, "山本二郎", 16, "09022222222"));
+        verify(clientMapper, times(2)).findById(2);
+    }
+
+    @Test
+    public void 存在しないIDを更新しようとするとエラーを返す() throws ClientNotFoundException {
+        doReturn(Optional.empty()).when(clientMapper).findById(99);
+
+        assertThatThrownBy(() -> {
+            clientServiceImpl.update(99, "山本二郎", 16, "09022222222");
+        })
+                .isInstanceOf(ClientNotFoundException.class)
+                .hasMessage("resource not found");
+        verify(clientMapper, times(2)).findById(99);
     }
 }


### PR DESCRIPTION
# 概要
Serviceの更新処理の単体テストを実装しました。
具体的には、「特定IDの顧客情報の更新」と「存在しないIDをリクエストした時の例外処理」を実装しています。
# 動作確認
 ### 顧客データの更新処理　
* ID2の顧客データを更新
![updateID2](https://github.com/minori-oya/task10/assets/138114043/8178fc4e-0e06-4573-baca-6695f4604ab4)
* 存在しないID99をリクエストした時の例外処理 
![updateID99](https://github.com/minori-oya/task10/assets/138114043/9bc438ac-7001-4194-9a1a-254183c568b3)
