### PR TITLE
顧客データの削除処理の単体テストを実装

### DIFF
--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -109,7 +109,7 @@ public class ClientServiceImplTest {
         assertThatThrownBy(() -> clientServiceImpl.delete(99))
                 .isInstanceOf(ClientNotFoundException.class)
                 .hasMessage("resource not found");
-        verify(clientMapper, times(3)).findById(99);
+        verify(clientMapper, times(1)).findById(99);
         verify(clientMapper, times(0)).delete(99);
     }
 }

--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -93,4 +93,22 @@ public class ClientServiceImplTest {
                 .hasMessage("resource not found");
         verify(clientMapper, times(2)).findById(99);
     }
+
+    @Test
+    public void 顧客データを削除する() {
+        Client client = new Client(3, "佐藤三郎", 30, "08033333333");
+        doReturn(Optional.of(client)).when(clientMapper).findById(3);
+        clientServiceImpl.delete(3);
+        verify(clientMapper).delete(3);
+    }
+
+    @Test
+    public void 存在しないIDを削除しようとするとエラーを返す() throws ClientNotFoundException {
+        doReturn(Optional.empty()).when(clientMapper).findById(99);
+
+        assertThatThrownBy(() -> clientServiceImpl.delete(99))
+                .isInstanceOf(ClientNotFoundException.class)
+                .hasMessage("resource not found");
+        verify(clientMapper, times(3)).findById(99);
+    }
 }

--- a/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
+++ b/src/test/java/com/task10/crudapi_login/service/ClientServiceImplTest.java
@@ -110,5 +110,6 @@ public class ClientServiceImplTest {
                 .isInstanceOf(ClientNotFoundException.class)
                 .hasMessage("resource not found");
         verify(clientMapper, times(3)).findById(99);
+        verify(clientMapper, times(0)).delete(99);
     }
 }


### PR DESCRIPTION
# 概要
Serviceの削除処理の単体テストを実装しました。
具体的には、「特定IDの顧客情報の削除」と「存在しないIDをリクエストした時の例外処理」を実装しています。
# 動作確認
### 顧客データの削除処理
* ID3の顧客データを削除
![deleteID3](https://github.com/minori-oya/task10/assets/138114043/dd41a227-d047-493b-be71-d8d554558e3c)
* 存在しないID99をリクエストした時の例外処理
![deleteID99](https://github.com/minori-oya/task10/assets/138114043/49dff843-8f3c-4346-9166-99584cb144d7)
