### PR TITLE
MapperのDBテスト(READ処理)を実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
+    testImplementation 'com.github.database-rider:rider-spring:1.41.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/task10/crudapi_login/mapper/ClientMapperTest.java
+++ b/src/test/java/com/task10/crudapi_login/mapper/ClientMapperTest.java
@@ -1,0 +1,56 @@
+package com.task10.crudapi_login.mapper;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import com.task10.crudapi_login.entity.Client;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ClientMapperTest {
+    @Autowired
+    ClientMapper clientMapper;
+
+    @Test
+    @DataSet(value = "datasets/clients.yml")
+    @Transactional
+    void 顧客データを全件取得すること() {
+        List<Client> clients = clientMapper.findAll();
+        assertThat(clients)
+                .hasSize(3)
+                .contains(
+                        new Client(1, "田中一郎", 20, "09011111111"),
+                        new Client(2, "鈴木二郎", 15, "08022222222"),
+                        new Client(3, "佐藤三郎", 30, "08033333333")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/clients.yml")
+    @Transactional
+    void 存在するIDを指定した時に特定の顧客データを取得すること() {
+        Optional<Client> clients = clientMapper.findById(1);
+        assertThat(clients)
+                .contains(
+                        new Client(1, "田中一郎", 20, "09011111111")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/clients.yml")
+    @Transactional
+    void 存在しないIDを指定する場合にListが空の情報を取得すること() {
+        Optional<Client> clients = clientMapper.findById(99);
+        assertThat(clients).isEmpty();
+    }
+}

--- a/src/test/resources/datasets/clients.yml
+++ b/src/test/resources/datasets/clients.yml
@@ -1,0 +1,13 @@
+clients:
+  - id: 1
+    name: "田中一郎"
+    age: 20
+    phoneNumber: "09011111111"
+  - id: 2
+    name: "鈴木二郎"
+    age: 15
+    phoneNumber: "08022222222"
+  - id: 3
+    name: "佐藤三郎"
+    age: 30
+    phoneNumber: "08033333333"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: clients_login_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/clients_login_list"
+  user: "user"
+  password: "password"


### PR DESCRIPTION
# 概要
MapperのDBテスト、顧客情報の読み取り処理を実装いたしました。
全件取得、特定IDの顧客データを取得、存在しないIDをリクエストした際にデータが空であることを返す実装しています。
全てテスト成功を検証しています。
# 動作確認
### [顧客データを全件取得]
![Read 全件取得　DBテスト](https://github.com/minori-oya/task10/assets/138114043/ec6561f8-9961-4800-9190-f08a499295e7)
### [特定IDの顧客データを取得]
![Read ID1 DBテスト](https://github.com/minori-oya/task10/assets/138114043/58945650-9f69-4ab5-9972-96a100fbc08c)
### [存在しないIDをリクエストした際にデータが空の情報を取得]
![Read ID99 DBテスト](https://github.com/minori-oya/task10/assets/138114043/9a88b267-3a63-4a4c-a6be-4571719c7f61)
